### PR TITLE
Refactor Get-SecondTuesday function to use default month and year values

### DIFF
--- a/2023.5.17.1/public/Get-SecondTuesday.ps1
+++ b/2023.5.17.1/public/Get-SecondTuesday.ps1
@@ -4,10 +4,9 @@ function Get-SecondTuesday {
   param
   (
     [int]
-    $Month,
-
+    $Month = (Get-Date -Format 'MM'),
     [int]
-    $Year
+    $Year = (Get-Date -Format 'yyyy')
   )
 
   [int]$Day = 1


### PR DESCRIPTION
Gets the month and year of the current date as default values.
